### PR TITLE
keyutils: inherit autotools-brokensep

### DIFF
--- a/recipes-support/keyutils/keyutils_1.5.9.bb
+++ b/recipes-support/keyutils/keyutils_1.5.9.bb
@@ -26,7 +26,7 @@ SRC_URI_append_powerpc = "file://keyutils-fix-powerpc-cflags.patch"
 
 S = "${WORKDIR}/git"
 
-inherit autotools
+inherit autotools-brokensep
 
 INSTALL_FLAGS = " \
     LIBDIR=${libdir} \


### PR DESCRIPTION
Fix build error:

  make: *** No targets specified and no makefile found. Stop.

Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>