### PR TITLE
README.md: use "EFI Secure Boot" only

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ in your product, because they are completely public.
 ### Best practice
 The following best practices should be applied with using IMA.
 
-- Enable UEFI/MOK secure boot
-  UEFI/MOK secure boot can verify the integrity of initramfs, providing the
+- Enable EFI Secure Boot
+  EFI Secure Boot can verify the integrity of initramfs, providing the
   protection against tampering of the external IMA policy files and IMA public
   keys stored in initramfs.
 


### PR DESCRIPTION
The UEFI and MOK Secure Boot have been merged as EFI Secure Boot.

Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>